### PR TITLE
Updating to use tibble 2.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports: dplyr,
   readr,
   rlang,
   stringr,
-  tibble,
+  tibble (>= 2.1.1),
   tidyr
 Suggests: testthat
 RoxygenNote: 6.0.1

--- a/R/manip_strings.R
+++ b/R/manip_strings.R
@@ -33,7 +33,7 @@ str_locate_whichever <- function (string, patterns) {
   
   out <- map(patterns, ~str_locate(string, .)) %>%
     reduce(cbind) %>%
-    as_tibble() %>%
+    as_tibble(.name_repair = "universal") %>%
     mutate(starts = coalesce(!!! select(., starts_with("start"))),
            ends = coalesce(!!! select(., starts_with("end"))))
   


### PR DESCRIPTION
`str_locate_whichever()` uses `tibble::as_tibble()` under the hood, and was assuming the OLD name repair behavior. Now it doesn't! Was breaking `super_gather()` but now fixed.